### PR TITLE
Change product buttons behavior on product hover

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -47,7 +47,7 @@ const ProductBox = ({ name, price, promo, stars }) => (
         </Button>
       </div>
       <div className={styles.price}>
-        <Button noHover variant='small'>
+        <Button className={styles.btnprice} noHover variant='small'>
           $ {price}
         </Button>
       </div>

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -29,8 +29,18 @@
     }
 
     .buttons {
+      visibility:hidden;
       display: flex;
       justify-content: space-between;
+    }
+  }
+
+  &:hover {
+    .buttons {
+      visibility: visible;
+    }
+    .btnprice {
+      background-color: $primary;
     }
   }
 


### PR DESCRIPTION
Pull request for following task: https://projects.kodilla.com/secure/RapidBoard.jspa?rapidView=205&projectKey=WDP230201&view=detail&selectedIssue=WDP230201-4

This commit addresses need of showing buttons (quick view and add to cart) only when hovering on product. Another behavior added is price element change (to primary - orange - color) when product is hovered.